### PR TITLE
Added links to marg 0.8.1-SNAP

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-marginalia "0.8.0"
+(defproject lein-marginalia "0.8.1-SNAPSHOT"
   :description "Leiningen plugin for Marginalia."
   :url "http://github.com/fogus/marginalia"
-  :dependencies [[marginalia "0.8.0"]]
+  :dependencies [[marginalia "0.8.1-SNAPSHOT"]]
   :eval-in :leiningen)
 

--- a/src/leiningen/marg.clj
+++ b/src/leiningen/marg.clj
@@ -14,7 +14,7 @@
       (eip project form init)
       (eip project form nil nil init))))
 
-(def dep ['marginalia "0.8.0"])
+(def dep ['marginalia "0.8.1-SNAPSHOT"])
 
 (defn- add-marg-dep [project]
   ;; Leiningen 2 is a bit smarter about only conjing it in if it


### PR DESCRIPTION
This keeps the lein plugin in sync with the changes addressed in marginalia#134.